### PR TITLE
Bump build.zig to zig 0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,7 +63,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "nemu-zig",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -74,11 +74,9 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    regex_lib.addIncludePath(.{ .path = "lib" });
+    regex_lib.addIncludePath(b.path("lib"));
     regex_lib.addCSourceFile(.{
-        .file = .{
-            .path = "lib/regex_slim.c",
-        },
+        .file = b.path("lib/regex_slim.c"),
         .flags = &.{"-std=c99"},
     });
     regex_lib.linkLibC();
@@ -91,11 +89,9 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
         });
-        llvm_lib.addIncludePath(.{ .path = "lib" });
+        llvm_lib.addIncludePath(b.path("lib"));
         llvm_lib.addCSourceFile(.{
-            .file = .{
-                .path = "lib/llvm_slim.c",
-            },
+            .file = b.path("lib/llvm_slim.c"),
             .flags = &.{"-std=c99"},
         });
         llvm_lib.linkLibC();
@@ -103,7 +99,7 @@ pub fn build(b: *std.Build) void {
         exe.linkSystemLibrary("LLVM");
     }
 
-    exe.addIncludePath(.{ .path = "lib" });
+    exe.addIncludePath(b.path("lib"));
     exe.linkLibC();
     exe.root_module.addOptions("config", options);
 
@@ -123,14 +119,14 @@ pub fn build(b: *std.Build) void {
 
     // zig test
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/test.zig" },
+        .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     unit_tests.root_module.addOptions("config", options);
     unit_tests.linkLibrary(regex_lib);
-    unit_tests.addIncludePath(.{ .path = "lib" });
+    unit_tests.addIncludePath(b.path("lib"));
     unit_tests.linkLibC();
 
     const run_unit_tests = b.addRunArtifact(unit_tests);


### PR DESCRIPTION
Update `build.zig` to use `.path` for specifying file paths.

The current build.zig script encounters errors when trying to build the project. The error message encountered is:
```shell
$ zig build run
/Users/qimingchu/workbench/nemu-zig/build.zig:66:33: error: no field named 'path' in union 'Build.LazyPath'
        .root_source_file = .{ .path = "src/main.zig" },
                                ^~~~
/opt/homebrew/Cellar/zig/0.13.0/lib/zig/std/Build.zig:2171:22: note: union declared here
pub const LazyPath = union(enum) {
                     ^~~~~
referenced by:
    runBuild__anon_8408: /opt/homebrew/Cellar/zig/0.13.0/lib/zig/std/Build.zig:2116:27
    main: /opt/homebrew/Cellar/zig/0.13.0/lib/zig/compiler/build_runner.zig:301:29
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```